### PR TITLE
Remove the double entry of a paper

### DIFF
--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -374,18 +374,6 @@
   plugin: sources.py
   file: sources.yaml
   image: https://media.springernature.com/full/springer-static/image/art%3A10.1038%2Fs41467-020-15754-3/MediaObjects/41467_2020_15754_Fig1_HTML.png?as=webp
-- id: doi:10.1175/jpo-d-24-0061.1
-  title: Does Cabbeling Shape the Thermohaline Structure of High-Latitude Oceans?
-  authors:
-  - Josef I. Bisits
-  - Jan D. Zika
-  - Dafydd Gwyn Evans
-  publisher: Journal of Physical Oceanography
-  date: '2024-12-01'
-  link: https://doi.org/g8t62t
-  orcid: 0000-0003-3462-3559
-  plugin: orcid.py
-  file: orcid.yaml
 - id: doi:10.1029/2023jc020259
   title: The Ocean's Meridional Oxygen Transport
   authors:


### PR DESCRIPTION
I think this has to do with the doi being updated to upper case? Only reason I can see at first glance.